### PR TITLE
Removed docker push from build script

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -4,31 +4,21 @@
 
 .DESCRIPTION
     This script builds a Docker image for the WakeOnLanService application.
-    If the --build-only parameter is set, it only builds the image without pushing it to the Docker repository.
-    If the --run parameter is set, it runs the Docker container after building and optionally pushing.
-
-.PARAMETER BuildOnly
-    If set, the script will only build the Docker image and not push it to the repository.
+    If the -Run parameter is set, it runs the Docker container after building
 
 .PARAMETER Run
     If set, the script will run the Docker container after building and optionally pushing.
 
 .EXAMPLE
     .\build.ps1
-    Builds and pushes the Docker image.
-
-.EXAMPLE
-    .\build.ps1 -BuildOnly
-    Only builds the Docker image without pushing it to the repository.
+    Only builds the Docker image without running
 
 .EXAMPLE
     .\build.ps1 -Run
     Builds and runs the Docker container without pushing it to the repository.
 #>
 
-# Define parameters to check if the --build-only or --run switches are set
 param (
-    [switch]$BuildOnly,
     [switch]$Run
 )
 
@@ -61,25 +51,16 @@ Set-EnvVarsFromDotEnv -envFilePath ".env"
 
 # Build the Docker image
 Write-Output "Building the Docker image..."
-docker build -t drache42/wakeonlanservice:latest -f docker/Dockerfile .
+docker build -t drache42/wakeonlanservice:local -f docker/Dockerfile .
 
 # If the --build-only switch is set, exit after building the image
 if ($BuildOnly) {
-    Write-Output "Build only, not pushing to Docker repository."
     exit 0
 }
 
 # If the --run switch is set, run the Docker container after building the image
 if ($Run) {
     Write-Output "Running the Docker container..."
-    docker run -it --rm -p 4200:4200 -e URL=$env:URL -e MAC_ADDRESS=$env:MAC_ADDRESS drache42/wakeonlanservice:latest
+    docker run -it --rm -p 4200:4200 -e URL=$env:URL -e MAC_ADDRESS=$env:MAC_ADDRESS drache42/wakeonlanservice:local
     exit 0
 }
-
-# Log in to Docker
-Write-Output "Logging in to Docker..."
-docker login
-
-# Push the Docker image to the repository
-Write-Output "Pushing the Docker image to the repository..."
-docker push drache42/wakeonlanservice:latest


### PR DESCRIPTION
This pull request includes changes to the `build.ps1` script for building and running the WakeOnLanService Docker image. The main changes involve simplifying the script by removing the `BuildOnly` parameter and modifying the Docker image tag.

Simplification of script parameters and Docker image handling:

* Removed the `BuildOnly` parameter and its associated logic, simplifying the script to either build or build and run the Docker image based on the `Run` parameter.
* Changed the Docker image tag from `latest` to `local` to better reflect the local build context.