### PR TITLE
Created docker release process

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -44,11 +44,9 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile
-          push: false
+          push: true
           load: true
           tags: |
             drache42/wakeonlanservice:${{ env.VERSION }}
             drache42/wakeonlanservice:latest
-
-      - name: Verify Docker image
-        run: docker run --rm drache42/wakeonlanservice:${{ env.VERSION }} --version
+      

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -45,6 +45,7 @@ jobs:
           context: .
           file: docker/Dockerfile
           push: false
+          load: true
           tags: |
             drache42/wakeonlanservice:${{ env.VERSION }}
             drache42/wakeonlanservice:latest

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,51 @@
+name: Publish Docker Image
+
+on:
+  push:
+    tags:
+      - 'release/**'
+
+jobs:
+  publish:
+    name: Publish Docker Image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Validate tag format
+        run: |
+          if [[ ! $GITHUB_REF =~ ^refs/tags/release/[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Invalid tag format. Expected 'release/major.minor.patch'."
+            exit 1
+          fi
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # - name: Log in to Docker Hub
+      #   uses: docker/login-action@v3
+      #   with:
+      #     username: ${{ secrets.DOCKER_USERNAME }}
+      #     password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Extract version from tag
+        id: extract_version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/release/}" >> $GITHUB_ENV
+
+      - name: Write VERSION file
+        run: echo ${{ env.VERSION }} > VERSION
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: docker/Dockerfile
+          push: true
+          tags: |
+            drache42/wakeonlanservice:${{ env.VERSION }}
+            drache42/wakeonlanservice:latest
+
+      - name: Verify Docker image
+        run: docker run --rm drache42/wakeonlanservice:${{ env.VERSION }} --version

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -22,11 +22,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      # - name: Log in to Docker Hub
-      #   uses: docker/login-action@v3
-      #   with:
-      #     username: ${{ secrets.DOCKER_USERNAME }}
-      #     password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Extract version from tag
         id: extract_version

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,7 +2,11 @@ name: Publish Docker Image
 
 on:
   workflow_call:
-
+    secrets:
+        DOCKER_USERNAME:
+            required: true
+        DOCKER_PASSWORD:
+            required: true
 jobs:
   publish:
     name: Publish Docker Image

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,9 +1,7 @@
 name: Publish Docker Image
 
 on:
-  push:
-    tags:
-      - 'release/**'
+  workflow_call:
 
 jobs:
   publish:
@@ -42,7 +40,7 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile
-          push: true
+          push: false
           tags: |
             drache42/wakeonlanservice:${{ env.VERSION }}
             drache42/wakeonlanservice:latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+      - 'refs/tags/release/**'
   workflow_dispatch:
 
 jobs:
@@ -25,3 +26,8 @@ jobs:
     uses: ./.github/workflows/integration-tests.yml
     with:
       python-version: "3.13"
+
+  docker-publish:
+    needs: [lint, unit-tests, integration-tests]
+    if: startsWith(github.ref, 'refs/tags/release/')
+    uses: ./.github/workflows/docker-publish.yml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,8 +8,10 @@ on:
     branches:
       - main
       - 'refs/tags/release/**'
+    tags:
+      - 'release/**'
   workflow_dispatch:
-
+        
 jobs:
   lint:
     uses: ./.github/workflows/linter.yml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,8 @@ on:
     branches:
       - main
       - 'refs/tags/release/**'
+    tags:
+      - 'release/**'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,10 +8,8 @@ on:
     branches:
       - main
       - 'refs/tags/release/**'
-    tags:
-      - 'release/**'
   workflow_dispatch:
-        
+
 jobs:
   lint:
     uses: ./.github/workflows/linter.yml
@@ -33,3 +31,6 @@ jobs:
     needs: [lint, unit-tests, integration-tests]
     if: startsWith(github.ref, 'refs/tags/release/')
     uses: ./.github/workflows/docker-publish.yml
+    secrets:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/README.md
+++ b/README.md
@@ -90,3 +90,7 @@ Run `build.ps1 -Run` to build and run the container.
 To run tests, simply run command `poetry run pytest`. This will run all tests.
 
 If you only want to run unit tests, run: `poetry run pytest tests/unit`
+
+## Dockerhub
+
+Docker container can be found at <https://hub.docker.com/r/drache42/wakeonlanservice>


### PR DESCRIPTION
This pull request introduces a new workflow for publishing Docker images and updates the main workflow to include this new process. The most important changes include adding a new workflow file for Docker image publishing and modifying the main workflow to trigger the Docker publish job on specific tags.

### New Docker Image Publishing Workflow:

* [`.github/workflows/docker-publish.yml`](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98R1-R52): Added a new workflow to publish Docker images. This includes steps for validating tag format, setting up Docker Buildx, logging into Docker Hub, extracting the version from the tag, writing the VERSION file, and building and pushing the Docker image.

### Updates to Main Workflow:

* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3R10-R12): Modified the `on:` section to trigger on tags matching `release/**`.
* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3R31-R38): Added a new job `docker-publish` that depends on the completion of lint, unit-tests, and integration-tests jobs. This job uses the new Docker publish workflow and passes necessary secrets.