### PR TITLE
Updated App to track attempts in sessions rather then globally

### DIFF
--- a/src/wakeonlanservice/__init__.py
+++ b/src/wakeonlanservice/__init__.py
@@ -18,19 +18,23 @@ def create_app(test_config=None) -> Flask:
     Returns:
         Flask: The Flask application instance.
     """
-    app = Flask(__name__)
+    app = Flask(__name__, instance_relative_config=True)
 
-    # Set up logging
-    setup_logging(app.debug)
+    # Set default configuration
+    app.config.from_mapping(
+        SECRET_KEY=os.environ.get("SECRET_KEY", os.urandom(24)),
+        TESTING=False,
+    )
 
     # Apply the test configuration if provided
     if test_config:
         app.config.update(test_config)
 
+    # Set up logging
+    setup_logging(app.debug)
+
     # Validate environment variables
     validate_env_variables()
-
-    app.config["ATTEMPTS"] = 0
 
     # Register blueprints
     app.register_blueprint(status_bp)

--- a/src/wakeonlanservice/app.py
+++ b/src/wakeonlanservice/app.py
@@ -1,8 +1,11 @@
 # Import the create_app function
 from wakeonlanservice import create_app
+import os
 
-# Create the Flask application instance
-app = create_app()
+# Create the Flask application instance with a secret key for sessions
+app = create_app({
+    "SECRET_KEY": os.environ.get("SECRET_KEY", os.urandom(24))
+})
 
 if __name__ == "__main__":
     # Run the Flask application

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -5,6 +5,7 @@ from wakeonlanservice import create_app, validate_env_variables
 class TestCreateApp:
     def test_app_creation(self):
         app = create_app({"TESTING": True})
+        
         assert isinstance(app, Flask)
         assert app is not None
         assert app.config["TESTING"] is True
@@ -13,17 +14,21 @@ class TestCreateApp:
         # Set FLASK_DEBUG environment variable to '0' (False)
         monkeypatch.setenv("FLASK_DEBUG", "0")
         app = create_app()
+        
         assert isinstance(app, Flask)
         assert app.debug is False
-        assert app.config["ATTEMPTS"] == 0
+        assert "SECRET_KEY" in app.config
+        assert app.config["SECRET_KEY"] is not None
 
     def test_create_app_debug(self, monkeypatch):
         # Set FLASK_DEBUG environment variable to '1' (True)
         monkeypatch.setenv("FLASK_DEBUG", "1")
         app = create_app()
+        
         assert isinstance(app, Flask)
         assert app.debug is True
-        assert app.config["ATTEMPTS"] == 0
+        assert "SECRET_KEY" in app.config
+        assert app.config["SECRET_KEY"] is not None
 
 class TestValidateEnvVariables:
     def test_validate_env_variables_valid(self, monkeypatch):

--- a/tests/unit/test_status.py
+++ b/tests/unit/test_status.py
@@ -2,10 +2,19 @@ import pytest
 import requests
 from wakeonlanservice import create_app
 from wakeonlanservice.blueprints.status import check_url_status
+import os
+from unittest.mock import patch
 
 @pytest.fixture
 def app(scope="function"):
-    app = create_app({"TESTING": True})
+    """Create and configure a Flask app for testing."""
+    app = create_app({
+        "TESTING": True,
+        "SECRET_KEY": "test_secret_key"  # Set a fixed secret key for testing
+    })
+    # Set environment variables for testing
+    os.environ["MAC_ADDRESS"] = "00:11:22:33:44:55"
+    os.environ["URL"] = "http://example.com"
     return app
 
 @pytest.fixture
@@ -35,59 +44,78 @@ class TestCheckUrlStatus:
 
 class TestMultipleAppInstances:
     def test_multiple_app_instances_attempts(self):
-        app1 = create_app({"TESTING": True})
-        app2 = create_app({"TESTING": True})
+        # Create two separate app instances with their own clients
+        app1 = create_app({"TESTING": True, "SECRET_KEY": "test_key_1"})
+        app2 = create_app({"TESTING": True, "SECRET_KEY": "test_key_2"})
         
         client1 = app1.test_client()
-        client1.get("/check_url")
-        assert app1.config["ATTEMPTS"] == 1
-
         client2 = app2.test_client()
-        client2.get("/check_url")
-        assert app2.config["ATTEMPTS"] == 1
+        
+        # Set up mocking for check_url_status and send_magic_packet
+        with patch("wakeonlanservice.blueprints.status.check_url_status", return_value=False):
+            with patch("wakeonlanservice.blueprints.status.send_magic_packet"):
+                # Initialize sessions
+                client1.get("/")
+                client2.get("/")
+                
+                # First client makes 3 attempts
+                for _ in range(3):
+                    client1.get("/check_url")
+                
+                # Second client makes 1 attempt
+                client2.get("/check_url")
+                
+                # Get current state
+                response1 = client1.get("/check_url")
+                response2 = client2.get("/check_url")
+                
+                # Verify each client has its own separate attempt count
+                assert response1.get_json()["attempts"] == 4
+                assert response2.get_json()["attempts"] == 2
 
 class TestCheckUrl:
     def test_check_url_available(self, monkeypatch, client):
-        def mock_get(*args, **kwargs):
-            class MockResponse:
-                status_code = 200
-            return MockResponse()
-        monkeypatch.setattr("requests.get", mock_get)
-        
-        response = client.get("/check_url")
-        assert response.status_code == 200
-        data = response.get_json()
-        assert data["status"] == "available"
-        assert data["attempts"] == 1
+        with patch("wakeonlanservice.blueprints.status.check_url_status", return_value=True):
+            with patch("wakeonlanservice.blueprints.status.send_magic_packet"):
+                # Initialize session
+                client.get("/")
+                
+                # Check URL
+                response = client.get("/check_url")
+                assert response.status_code == 200
+                data = response.get_json()
+                assert data["status"] == "available"
+                assert data["attempts"] == 1
 
     def test_check_url_unavailable(self, monkeypatch, client):
-        def mock_get(*args, **kwargs):
-            class MockResponse:
-                status_code = 404
-            return MockResponse()
-        monkeypatch.setattr("requests.get", mock_get)
-        
-        response = client.get("/check_url")
-        assert response.status_code == 200
-        data = response.get_json()
-        assert data["status"] == "unavailable"
-        assert data["attempts"] == 1
+        with patch("wakeonlanservice.blueprints.status.check_url_status", return_value=False):
+            with patch("wakeonlanservice.blueprints.status.send_magic_packet"):
+                # Initialize session
+                client.get("/")
+                
+                # Check URL
+                response = client.get("/check_url")
+                assert response.status_code == 200
+                data = response.get_json()
+                assert data["status"] == "unavailable"
+                assert data["attempts"] == 1
 
     def test_check_url_error(self, monkeypatch, client):
-        def mock_get(*args, **kwargs):
-            class MockResponse:
-                status_code = 404
-            return MockResponse()
-        monkeypatch.setattr("requests.get", mock_get)
-        
-        for _ in range(10):
-            client.get("/check_url")
-        
-        response = client.get("/check_url")
-        assert response.status_code == 200
-        data = response.get_json()
-        assert data["status"] == "error"
-        assert data["attempts"] == 11
+        with patch("wakeonlanservice.blueprints.status.check_url_status", return_value=False):
+            with patch("wakeonlanservice.blueprints.status.send_magic_packet"):
+                # Initialize session
+                client.get("/")
+                
+                # Make 10 attempts
+                for _ in range(10):
+                    client.get("/check_url")
+                
+                # Check status after threshold
+                response = client.get("/check_url")
+                assert response.status_code == 200
+                data = response.get_json()
+                assert data["status"] == "error"
+                assert data["attempts"] == 11
 
 class TestHealthCheck:
     def test_healthcheck(self, client):


### PR DESCRIPTION
This pull request introduces session-based tracking for the number of attempts in the Wake-on-LAN service, replacing the previous global application state approach. It also enhances the application configuration and updates the corresponding tests to reflect these changes.

### Application Configuration Updates:
* Modified `create_app` in `src/wakeonlanservice/__init__.py` to use `instance_relative_config=True` and added a default configuration with `SECRET_KEY` and `TESTING` values. (`[src/wakeonlanservice/__init__.pyL21-L34](diffhunk://#diff-9f9c5b75d118fb79c9eeac61b8fb5d50f02d0d8d304962eae93f77b0a9e0a50eL21-L34)`)
* Updated `src/wakeonlanservice/app.py` to pass a `SECRET_KEY` during app creation, ensuring secure session handling. (`[src/wakeonlanservice/app.pyR3-R8](diffhunk://#diff-0a87bdac4315a2a87ec46d673b02d7bd8dc2e656dab3d7b5474b0153e7fa7fcfR3-R8)`)

### Session-Based Attempt Tracking:
* Introduced session-based tracking for the `attempts` counter in `src/wakeonlanservice/blueprints/status.py`, replacing the global `current_app.config["ATTEMPTS"]`. This ensures per-session isolation of the counter. (`[[1]](diffhunk://#diff-8f259fd8657dff014b6e35ec7e32814514b55790783fbe3a496d6a71f67f1d13R30-R33)`, `[[2]](diffhunk://#diff-8f259fd8657dff014b6e35ec7e32814514b55790783fbe3a496d6a71f67f1d13L54-R61)`, `[[3]](diffhunk://#diff-8f259fd8657dff014b6e35ec7e32814514b55790783fbe3a496d6a71f67f1d13L70-R85)`)

### Test Suite Enhancements:
* Updated `tests/unit/test_app.py` to validate the presence and integrity of `SECRET_KEY` in the app configuration. Removed assertions related to the deprecated `ATTEMPTS` configuration. (`[tests/unit/test_app.pyR17-R31](diffhunk://#diff-fcbbe89d576bb1122eba8970740c18a3f3eb876b634ed6b62789d7561cae8372R17-R31)`)
* Enhanced `tests/unit/test_status.py` to include session initialization and mocking for testing session-specific behavior, including multiple app instances and attempt counters. (`[[1]](diffhunk://#diff-1f6a6d9200040e2b045b49c7118ce4ef04d36692c67cf7802961c914a91a46d6R5-R17)`, `[[2]](diffhunk://#diff-1f6a6d9200040e2b045b49c7118ce4ef04d36692c67cf7802961c914a91a46d6L38-R113)`)…y configuration