### PR TITLE
Add multi-arch (amd64+arm64) Docker image support

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -9,9 +9,17 @@ on:
 
 jobs:
   test:
-    name: Integration tests
-    runs-on: ubuntu-latest
-    
+    name: Integration tests (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -38,6 +46,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: test-results-integration
+          name: test-results-integration-${{ matrix.arch }}
           path: test-results/
           if-no-files-found: warn

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,12 +85,22 @@ jobs:
         run: .github/scripts/compute-version.ps1
 
   publish-main-image:
-    name: Publish branch image
-    runs-on: ubuntu-latest
+    name: Publish branch image (${{ matrix.suffix }})
+    runs-on: ${{ matrix.runner }}
     needs: [lint, unit-tests, integration-tests, compute-version]
     if: >-
       ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' &&
           needs.compute-version.result == 'success' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            suffix: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            suffix: arm64
     defaults:
       run:
         shell: pwsh
@@ -107,39 +117,83 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Compute image names
-        id: image_names
-        run: |
-          $shortSha = $env:GITHUB_SHA.Substring(0, 7)
-          "image=drache42/wakeonlanservice" | Add-Content -Path $env:GITHUB_OUTPUT
-          "short_sha=$shortSha" | Add-Content -Path $env:GITHUB_OUTPUT
-
-      - name: Build and push Docker image
+      - name: Build and push Docker image by digest
+        id: build
         uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/Dockerfile
-          push: true
-          tags: |
-            drache42/wakeonlanservice:main
-            drache42/wakeonlanservice:sha-${{ steps.image_names.outputs.short_sha }}
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=drache42/wakeonlanservice,push-by-digest=true,name-canonical=true,push=true
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
           build-args: |
             VERSION=${{ needs.compute-version.outputs.version }}
-          cache-from: type=gha,scope=app-image
-          cache-to: type=gha,mode=max,scope=app-image
+          cache-from: type=gha,scope=app-image-${{ matrix.suffix }}
+          cache-to: type=gha,mode=max,scope=app-image-${{ matrix.suffix }}
+
+      - name: Export digest
+        run: |
+          $digestId = "${{ steps.build.outputs.digest }}" -replace '^sha256:', ''
+          New-Item -ItemType Directory -Force -Path "$env:RUNNER_TEMP/digests" | Out-Null
+          New-Item -ItemType File -Force -Path "$env:RUNNER_TEMP/digests/$digestId" | Out-Null
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v7
+        with:
+          name: digests-${{ matrix.suffix }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge-main-image:
+    name: Merge multi-arch manifest
+    runs-on: ubuntu-latest
+    needs: [compute-version, publish-main-image]
+    if: >-
+      ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' &&
+          needs.compute-version.result == 'success' }}
+    defaults:
+      run:
+        shell: pwsh
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v7
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Create and push manifest list
+        env:
+          SHORT_SHA: ${{ needs.compute-version.outputs.short_sha }}
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          $refs = Get-ChildItem -File | ForEach-Object { "drache42/wakeonlanservice@sha256:$($_.Name)" }
+          docker buildx imagetools create `
+            --tag "drache42/wakeonlanservice:main" `
+            --tag "drache42/wakeonlanservice:sha-$env:SHORT_SHA" `
+            @refs
 
   auto-release:
     name: Auto-release
     runs-on: ubuntu-latest
-    needs: [compute-version, publish-main-image]
+    needs: [compute-version, merge-main-image]
     if: >-
       ${{ github.event_name == 'push' &&
           github.ref == 'refs/heads/main' &&
           needs.compute-version.outputs.skip == 'false' &&
-          needs.publish-main-image.result == 'success' }}
+          needs.merge-main-image.result == 'success' }}
     permissions:
       contents: write
     defaults:
@@ -215,7 +269,7 @@ jobs:
   notify-discord:
     name: Notify Discord on failures
     runs-on: ubuntu-latest
-    needs: [lint, unit-tests, integration-tests, test-summary, compute-version, publish-main-image, auto-release]
+    needs: [lint, unit-tests, integration-tests, test-summary, compute-version, publish-main-image, merge-main-image, auto-release]
     if: >-
       ${{ always() && (
         needs.lint.result == 'failure' ||
@@ -224,6 +278,7 @@ jobs:
         needs.test-summary.result == 'failure' ||
         needs.compute-version.result == 'failure' ||
         needs.publish-main-image.result == 'failure' ||
+        needs.merge-main-image.result == 'failure' ||
         needs.auto-release.result == 'failure'
       ) }}
     defaults:


### PR DESCRIPTION
## Summary
- Rework `publish-main-image` in `main.yml` into a native per-arch matrix (`ubuntu-latest` for amd64, `ubuntu-24.04-arm` for arm64) that pushes each platform by digest, plus a new `merge-main-image` job that combines both digests into one multi-arch manifest tagged `main`/`sha-<sha>`.
- Rewire `auto-release` and `notify-discord` to depend on `merge-main-image` instead of the old single-arch `publish-main-image` job. `auto-release`'s existing `imagetools create` promotion step needs no changes -- since it re-tags whatever manifest already exists at `sha-<sha>`, the promoted `X.Y.Z`/`X.Y`/`latest` tags automatically become multi-arch too.
- Matrix `integration-tests.yml` across the same two runners so the container is actually built and health-checked natively on arm64 hardware on every PR (this reusable workflow is called from both `pr.yml` and `main.yml`), not just amd64.
- No Dockerfile changes needed -- it's a multi-stage build on the multi-arch `python:*-alpine` base image with only pure-Python deps and `curl` via apk, nothing architecture-specific.

## Test plan
- [ ] Confirm `Integration tests (amd64)` and `Integration tests (arm64)` both pass in this PR's checks (validates `ubuntu-24.04-arm` is available to this repo and the container runs natively on arm64).
- [ ] After merge, confirm `publish-main-image (amd64)`, `publish-main-image (arm64)`, and `merge-main-image` all succeed in the `main.yml` run.
- [ ] Run `docker buildx imagetools inspect drache42/wakeonlanservice:main` and confirm the manifest list contains both `linux/amd64` and `linux/arm64`.
- [ ] If a release fires in that run, repeat the inspect against `:latest`/`:X.Y.Z`.